### PR TITLE
Updating LIST tag handling

### DIFF
--- a/R/rd2markdown.R
+++ b/R/rd2markdown.R
@@ -298,12 +298,17 @@ rd2markdown.itemize <- function(x, fragments = c(), ...) {
   paste0("\n", paste0("\n * ", items, "\n", collapse = ""), "\n", collapse = "")
 }
 
+#' `LIST` Rd tags are produced with an unnamed infotex function call. Whereas
+#' normal infotex syntax follows a \code{\\name\{arg\}} convention, naked
+#' \code{{arg}} will be captured as a `LIST`. This syntax has been adopted as a
+#' convention for package names. The desired rendering of this element is often
+#' ambiguous. To try to accommodate as many cases as possible, it is rendered as
+#' plain text.
+#'
 #' @exportS3Method
 #' @rdname rd2markdown
 rd2markdown.LIST <- function(x, fragments = c(), ...) {
-  warning("We've lost our notes about this method. Please report this issue to package
-           authors if you ever witness this warning so we can document it.")
-  paste0("* ", map_rd2markdown(x, fragments = fragments, ..., collapse = ""))
+  map_rd2markdown(x, fragments = fragments, ..., collapse = "")
 }
 
 #' @exportS3Method

--- a/man/rd2markdown.Rd
+++ b/man/rd2markdown.Rd
@@ -170,6 +170,13 @@ provided, other arguments are ignored.}
 }
 \description{
 Render a Rd object out to a markdown file
+
+\code{LIST} Rd tags are produced with an unnamed infotex function call. Whereas
+normal infotex syntax follows a \code{\\name\{arg\}} convention, naked
+\code{{arg}} will be captured as a \code{LIST}. This syntax has been adopted as a
+convention for package names. The desired rendering of this element is often
+ambiguous. To try to accommodate as many cases as possible, it is rendered as
+plain text.
 }
 \details{
 rd2markdown is the core function of the package. can work in various types. It accepts .Rd objects

--- a/tests/testthat/test-rd2markdown-list.R
+++ b/tests/testthat/test-rd2markdown-list.R
@@ -1,0 +1,9 @@
+test_that("rd2markdown formats LIST Rd_tags", {
+  list_rd <- rawRd("
+    \\describe{
+      This is a {test} of LIST Rd_tags.
+    }
+  ")
+
+  expect_match(rd2markdown(list_rd), "test of LIST Rd_tags")
+})

--- a/tests/testthat/test-rd2markdown-list.R
+++ b/tests/testthat/test-rd2markdown-list.R
@@ -1,9 +1,14 @@
 test_that("rd2markdown formats LIST Rd_tags", {
-  list_rd <- rawRd("
-    \\describe{
-      This is a {test} of LIST Rd_tags.
-    }
-  ")
+  list_rd <- rawRd("\\describe{This is a {test} of LIST Rd_tags.}")
 
-  expect_match(rd2markdown(list_rd), "test of LIST Rd_tags")
+  expect_silent({
+    which_describe <- lapply(list_rd, attr, "Rd_tag") == "\\describe"
+    describe <- list_rd[which_describe][[1L]]
+  })
+
+  # confirm that we actually produced a LIST Rd_tag as part of our test
+  expect_true(any(lapply(describe, attr, "Rd_tag") == "LIST"))
+
+  # test rendering of LIST element, {test}
+  expect_match(rd2markdown(list_rd), "is a test of")
 })

--- a/tests/testthat/test-rd2markdown-list.R
+++ b/tests/testthat/test-rd2markdown-list.R
@@ -1,7 +1,6 @@
 test_that("rd2markdown formats LIST Rd_tags", {
-  list_rd <- rawRd("\\describe{This is a {test} of LIST Rd_tags.}")
-
   expect_silent({
+    list_rd <- rawRd("\\describe{This is a {test} of LIST Rd_tags.}")
     which_describe <- lapply(list_rd, attr, "Rd_tag") == "\\describe"
     describe <- list_rd[which_describe][[1L]]
   })


### PR DESCRIPTION
Now that we have some examples of what produces the `LIST` tag, I updated the rendering and added a test. 

A pretty straightforward change, but I also documented the rationale for how it's rendered. Exactly what should be produced isn't exactly obvious.