### PR TITLE
Fix empty verb tag bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rd2markdown
 Title: Convert Rd Files into Markdown
-Version: 0.0.3
+Version: 0.0.4
 Authors@R: c(
     person(
         given = "Doug",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 rd2markdown 0.0.4
 -----------------
 
-* Fix the bug where empty `\verba{}` tag would cause `rd2markdown.code` to throw unexpected 
+* Fix the bug where empty `\verb{}` tag would cause `rd2markdown.code` to throw unexpected 
   warnings and NAs (#22 @maksymiuks).
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+rd2markdown 0.0.4
+-----------------
+
+* Fix the bug where empty `\verba{}` tag would cause `rd2markdown.code` to throw unexpected 
+  warnings and NAs (#22 @maksymiuks).
+
+
 rd2markdown 0.0.3
 -----------------
 

--- a/R/rd2markdown.R
+++ b/R/rd2markdown.R
@@ -112,17 +112,14 @@ rd2markdown.USERMACRO <- rd2markdown.NULL
 #' @rdname rd2markdown
 rd2markdown.code <- function(x, fragments = c(), ...) {
   opts <- list(code_quote = FALSE)
-  code <- paste0(
-    capture.output(tools::Rd2txt(list(x), fragment = TRUE, options = opts)),
-    collapse = ""
-  )
-  # Early escaping if code before splitting is of length 0
-  if (nchar(code) == 0) {
-    "` `"
-  } else {
-    max_cons_backticks <- max(nchar(strsplit(gsub("[^`]+", " ", code), "\\s+")[[1]]))
-    sprintf("%2$s%1$s%2$s", code, strrep("`", max_cons_backticks + 1))
-  }
+  code <- capture.output(tools::Rd2txt(list(x), fragment = TRUE, options = opts))
+  if (length(code) == 0 || nchar(code) == 0) {
+    code <- as.character(x)
+  } 
+  code <- paste0(code, collapse = "")
+  
+  max_cons_backticks <- max(nchar(strsplit(gsub("[^`]+", " ", code), "\\s+")[[1]]))
+  sprintf("%2$s%1$s%2$s", code, strrep("`", max_cons_backticks + 1))
 }
 
 #' @exportS3Method

--- a/R/rd2markdown.R
+++ b/R/rd2markdown.R
@@ -116,7 +116,7 @@ rd2markdown.code <- function(x, fragments = c(), ...) {
     capture.output(tools::Rd2txt(list(x), fragment = TRUE, options = opts)),
     collapse = ""
   )
-  # Early escaping if code before spletting is of length 0
+  # Early escaping if code before splitting is of length 0
   if (nchar(code) == 0) {
     "` `"
   } else {

--- a/R/rd2markdown.R
+++ b/R/rd2markdown.R
@@ -116,9 +116,13 @@ rd2markdown.code <- function(x, fragments = c(), ...) {
     capture.output(tools::Rd2txt(list(x), fragment = TRUE, options = opts)),
     collapse = ""
   )
-
-  max_cons_backticks <- max(nchar(strsplit(gsub("[^`]+", " ", code), "\\s+")[[1]]))
-  sprintf("%2$s%1$s%2$s", code, strrep("`", max_cons_backticks + 1))
+  # Early escaping if code before spletting is of length 0
+  if (nchar(code) == 0) {
+    "` `"
+  } else {
+    max_cons_backticks <- max(nchar(strsplit(gsub("[^`]+", " ", code), "\\s+")[[1]]))
+    sprintf("%2$s%1$s%2$s", code, strrep("`", max_cons_backticks + 1))
+  }
 }
 
 #' @exportS3Method


### PR DESCRIPTION
Candidate fix for #22 

In general, I implemented an early escape mechanism allowing rd2markdow to return the value immediately after an empty string was passed from `code` variable. Thanks to that we don't pass an empty string to `strsplit` that would return `character(0)` and this will propagate further eventually throwing warnings and NAs in the `max` function. Therefore the function now is safer and also more smooth.

One thin to decide is how empty verb (or code in general) should be displayed, whether it should be just a space or a space covered with backticks. Right now I implemented the latter as someone technically might want to display a space in the codish style (so grey background) but I'm open for other suggestions. 