### PR TITLE
Avoid warnings on extra long code tags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,29 +1,35 @@
 Package: rd2markdown
 Title: Convert Rd Files into Markdown
-Version: 0.0.4
-Authors@R: c(
-    person(
+Version: 0.0.5
+Authors@R:
+    c(
+      person(
         given = "Doug",
         family = "Kelkhoff",
         role = c("aut", "cre"),
-        email = "kelkhofd@gene.com"),
-    person(
+        email = "doug.kelkhoff@roche.com"
+      ),
+      person(
         given = "Lorenzo",
         family = "Braschi",
         role = "aut",
-        email = "lorenzo.braschi@roche.com"),
-    person(
+        email = "lorenzo.braschi@roche.com"
+      ),
+      person(
         given = "Szymon",
         family = "Maksymiuk",
         role = "aut",
-        email = "szymon.maksymiuk@roche.com"),
-    person(
+        email = "szymon.maksymiuk@roche.com"
+      ),
+      person(
         given = "Genentech, Inc.",
-        role = "cph"))
+        role = "cph"
+      )
+    )
 Description: A set of functions and methods allowing to convert R documentation
     files (.Rd) into markdown files. There is no need for pandoc or any other tool, 
     other than this package.
-Depends: 
+Depends:
     R (>= 3.2.0)
 Suggests:
     covr,
@@ -34,4 +40,4 @@ License: MIT + file LICENSE
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+rd2markdown 0.0.5
+-----------------
+
+* `\code{}` no longer throws unnecessary warnings for long `\code{}` contents.
+  (#28 @dgkf)
+
+
 rd2markdown 0.0.4
 -----------------
 

--- a/R/rd2markdown.R
+++ b/R/rd2markdown.R
@@ -113,11 +113,12 @@ rd2markdown.USERMACRO <- rd2markdown.NULL
 rd2markdown.code <- function(x, fragments = c(), ...) {
   opts <- list(code_quote = FALSE)
   code <- capture.output(tools::Rd2txt(list(x), fragment = TRUE, options = opts))
-  if (length(code) == 0 || nchar(code) == 0) {
-    code <- as.character(x)
-  } 
   code <- paste0(code, collapse = "")
-  
+
+  # safely handle zero-length code tags
+  if (length(code) == 0 || sum(nchar(code)) == 0)
+    return("` `")
+
   max_cons_backticks <- max(nchar(strsplit(gsub("[^`]+", " ", code), "\\s+")[[1]]))
   sprintf("%2$s%1$s%2$s", code, strrep("`", max_cons_backticks + 1))
 }

--- a/tests/testthat/test-rd2markdown-code.R
+++ b/tests/testthat/test-rd2markdown-code.R
@@ -3,3 +3,8 @@ test_that("rd2markdown code tags wrap code in single backticks", {
   expect_silent(md <- rd2markdown(rd))
   expect_equal(md, "`1 + 2`")
 })
+
+test_that("rd2markdown long code tags do not emit warnings (#28)", {
+  rd <- rawRd("\\code{a b c d e f g h i j k l m n o p q r s t u v w x y z a b c d e f g h i j k l m n o p q r s t u v w x y z}")
+  expect_silent(md <- rd2markdown(rd))
+})

--- a/tests/testthat/test-rd2markdown-verb.R
+++ b/tests/testthat/test-rd2markdown-verb.R
@@ -1,0 +1,5 @@
+test_that("rd2markdown verb empty tag does not throw warning (#22)", {
+  rd <- rawRd("\\verb{}")
+  expect_silent(md <- rd2markdown(rd))
+  expect_equal(md, "` `")
+})


### PR DESCRIPTION
Closes #28

Allows for the safety fuse for zero length verbs to work on extra long code tags that split into multiple lines using `capture.output(tools::Rd2txt(...))`.