### PR TITLE
Rework levels

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -15,7 +16,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -23,28 +24,39 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rd2markdown
 Title: Convert Rd Files into Markdown
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     c(
       person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+rd2markdown 0.1.2
+-----------------
+
+* Rework `level` parameter making it root level (title by default) which is later
+  used to determine depth od latter sections
+
 rd2markdown 0.1.1
 -----------------
 

--- a/man/rd2markdown.Rd
+++ b/man/rd2markdown.Rd
@@ -54,9 +54,9 @@
 \usage{
 rd2markdown(x, fragments = c(), ...)
 
-\method{rd2markdown}{Rd}(x, fragments = c(), ...)
+\method{rd2markdown}{Rd}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{list}(x, fragments = c(), ...)
+\method{rd2markdown}{list}(x, fragments = c(), ..., level = 1L)
 
 \method{rd2markdown}{`NULL`}(x, fragments = c(), ...)
 
@@ -84,37 +84,37 @@ rd2markdown(x, fragments = c(), ...)
 
 \method{rd2markdown}{default}(x, fragments = c(), ...)
 
-\method{rd2markdown}{title}(x, fragments = c(), ...)
+\method{rd2markdown}{title}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{description}(x, fragments = c(), ..., title = "Description", level = 2L)
+\method{rd2markdown}{description}(x, fragments = c(), ..., title = "Description", level = 1L)
 
-\method{rd2markdown}{author}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{author}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{format}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{format}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{details}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{details}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{note}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{note}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{source}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{source}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{value}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{value}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{section}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{section}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{subsection}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{subsection}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{examples}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{examples}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{usage}(..., level = 2L)
+\method{rd2markdown}{usage}(..., level = 1L)
 
-\method{rd2markdown}{preformatted}(x, fragments = c(), ..., title = NULL, language = "", level = 2L)
+\method{rd2markdown}{preformatted}(x, fragments = c(), ..., title = NULL, language = "", level = 1L)
 
-\method{rd2markdown}{references}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{references}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{seealso}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{seealso}(x, fragments = c(), ..., level = 1L)
 
-\method{rd2markdown}{arguments}(x, fragments = c(), ..., level = 2L)
+\method{rd2markdown}{arguments}(x, fragments = c(), ..., level = 1L)
 
 \method{rd2markdown}{dots}(x, fragments = c(), ...)
 
@@ -168,9 +168,9 @@ markdown-formatted help.}
 
 \item{...}{Additional arguments used by specific methods.}
 
-\item{title}{optional section title}
+\item{level}{Level (number of #') of the root section (title). Defaults to 1L}
 
-\item{level}{optional level parameter. 2L by default}
+\item{title}{optional section title}
 
 \item{language}{language to use as code fence syntax highlighter}
 

--- a/tests/testthat/test-rd2markdown.R
+++ b/tests/testthat/test-rd2markdown.R
@@ -133,3 +133,20 @@ test_that("rd2markdown works when file is provided, but parameter x missing", {
   expect_silent(md <- rd2markdown(file = file.path(test_path(), "data", "man", "rd_data_sampler.Rd")))
   expect_match(md, "# Rd data sampler\n\n## Format\n\nA")
 })
+
+
+test_that("rd2markdown prperly adds additional levels when specified", {
+  expect_silent(md <- rd2markdown(file = file.path(test_path(), "data", "man", "rd_sampler.Rd"), level = 3))
+  expect_match(md, "### Rd sampler title\n\n")
+  expect_match(md, "\n#### Arguments\n\n")
+  expect_match(md, "\n#### Returns\n\n")
+  expect_match(md, "\n#### Description\n\n")
+  expect_match(md, "\n#### Details\n\n")
+  expect_match(md, "\n#### Note\n\n")
+  expect_match(md, "\n#### Rd sampler subsection\n\n")
+  expect_match(md, "\n##### Rd sampler sub-subsection\n\n")
+  expect_match(md, "\n#### Examples\n\n")
+  expect_match(md, "\n#### References\n\n")
+  expect_match(md, "\n#### See Also\n\n")
+  expect_match(md, "\n#### Author\\(s\\)\n\n")
+})


### PR DESCRIPTION
We are reworking how the levels par parameter works. Previously, it used the default values and incremental passing to the `map_rd2markdown` function here and there to get a result. However, this only worked with standard levels (i.e., starting with just `#`) and was prone to errors. The main issue with that implementation is that some of the sections which we want to have different levels in the md file are on the same level in the rd object, meaning mapping is not that straightforward, for example - title and description are on the same level in the rd list. However, we want the description to be a subsection of the title in the md. Therefore, I reworked the parameter to increment level when necessary in the function instead of calling the function with increment from the parent object. This way, we can control which sections should have higher levels and which not. This approach will give us more control over how particular tags behave and how they render relative to the rest of the document.